### PR TITLE
stdenv: add enablePhaseMetrics parameter

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -176,7 +176,7 @@ let
 
   ghcEnv = ghc.withPackages (p: haskellBuildInputs);
 
-  setupCommand = "./Setup";
+  setupCommand = "perf-metrics $curPhase ./Setup";
 
   ghcCommand' = if isGhcjs then "ghcjs" else "ghc";
   ghcCommand = "${ghc.targetPrefix}${ghcCommand'}";

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -43,6 +43,7 @@ in
 , maintainers ? []
 , doCoverage ? false
 , doHaddock ? !(ghc.isHaLVM or false)
+, enablePhaseMetrics ? false
 , passthru ? {}
 , pkgconfigDepends ? [], libraryPkgconfigDepends ? [], executablePkgconfigDepends ? [], testPkgconfigDepends ? [], benchmarkPkgconfigDepends ? []
 , testDepends ? [], testHaskellDepends ? [], testSystemDepends ? []
@@ -176,7 +177,7 @@ let
 
   ghcEnv = ghc.withPackages (p: haskellBuildInputs);
 
-  setupCommand = "perf-metrics $curPhase ./Setup";
+  setupCommand = "performance-metrics $curPhase ./Setup";
 
   ghcCommand' = if isGhcjs then "ghcjs" else "ghc";
   ghcCommand = "${ghc.targetPrefix}${ghcCommand'}";
@@ -189,6 +190,7 @@ in
 assert allPkgconfigDepends != [] -> pkgconfig != null;
 
 stdenv.mkDerivation ({
+  inherit enablePhaseMetrics;
   name = "${pname}-${version}";
 
   outputs = [ "out" ] ++ (optional enableSeparateDataOutput "data") ++ (optional enableSeparateDocOutput "doc");

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -68,6 +68,7 @@ rec {
 
     , hardeningEnable ? []
     , hardeningDisable ? []
+    , enablePhaseMetrics ? false
 
     , ... } @ attrs:
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -144,6 +144,11 @@ exitHandler() {
         # - system time for all child processes
         echo "build time elapsed: " "${times[@]}"
     fi
+    if [ -n "${enablePhaseMetrics:-}" ] && [ -d "$out" ]; then
+        mkdir -p $out/nix-support
+        cat "$NIX_BUILD_TOP/metrics" >> "$out/nix-support/hydra-metrics"
+        cat "$out/nix-support/hydra-metrics"
+    fi
 
     if (( "$exitCode" != 0 )); then
         runHook failureHook
@@ -236,6 +241,19 @@ printLines() {
 printWords() {
     (( "$#" > 0 )) || return 0
     printf '%s ' "$@"
+}
+
+performance-metrics() {
+thingname=$1
+shift
+if [ -n "${enablePhaseMetrics:-}" ]; then
+  TIMEFORMAT="time.$thingname.user %U
+time.$thingname.system %S
+time.$thingname.real %R"
+  exec {fd}<&2; time ( "$@" 2>&$fd; ) 2>> "$NIX_BUILD_TOP/metrics"; exec {fd}<&-
+else
+  "$@"
+fi
 }
 
 ######################################################################
@@ -992,7 +1010,7 @@ buildPhase() {
         )
 
         echoCmd 'build flags' "${flagsArray[@]}"
-        make ${makefile:+-f $makefile} "${flagsArray[@]}"
+        performance-metrics "build" make ${makefile:+-f $makefile} "${flagsArray[@]}"
         unset flagsArray
     fi
 
@@ -1013,7 +1031,7 @@ checkPhase() {
     )
 
     echoCmd 'check flags' "${flagsArray[@]}"
-    make ${makefile:+-f $makefile} "${flagsArray[@]}"
+    performance-metrics "check" make ${makefile:+-f $makefile} "${flagsArray[@]}"
     unset flagsArray
 
     runHook postCheck
@@ -1038,7 +1056,7 @@ installPhase() {
     )
 
     echoCmd 'install flags' "${flagsArray[@]}"
-    make ${makefile:+-f $makefile} "${flagsArray[@]}"
+    performance-metrics "install" make ${makefile:+-f $makefile} "${flagsArray[@]}"
     unset flagsArray
 
     runHook postInstall
@@ -1197,6 +1215,7 @@ genericBuild() {
     fi
 
     for curPhase in $phases; do
+        start=$(date '+%s')
         if [[ "$curPhase" = buildPhase && -n "${dontBuild:-}" ]]; then continue; fi
         if [[ "$curPhase" = checkPhase && -z "${doCheck:-}" ]]; then continue; fi
         if [[ "$curPhase" = installPhase && -n "${dontInstall:-}" ]]; then continue; fi
@@ -1220,6 +1239,11 @@ genericBuild() {
 
         if [ "$curPhase" = unpackPhase ]; then
             cd "${sourceRoot:-.}"
+        fi
+        end=$(date '+%s')
+        duration=$((end - start))
+        if [ -n "${enablePhaseMetrics:-}" ]; then
+            echo "time.$curPhase $duration" >> "$NIX_BUILD_TOP/metrics"
         fi
     done
 }

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1215,7 +1215,7 @@ genericBuild() {
     fi
 
     for curPhase in $phases; do
-        start=$(date '+%s')
+        phase_start_time=$(date '+%s')
         if [[ "$curPhase" = buildPhase && -n "${dontBuild:-}" ]]; then continue; fi
         if [[ "$curPhase" = checkPhase && -z "${doCheck:-}" ]]; then continue; fi
         if [[ "$curPhase" = installPhase && -n "${dontInstall:-}" ]]; then continue; fi
@@ -1240,8 +1240,8 @@ genericBuild() {
         if [ "$curPhase" = unpackPhase ]; then
             cd "${sourceRoot:-.}"
         fi
-        end=$(date '+%s')
-        duration=$((end - start))
+        phase_end_time=$(date '+%s')
+        duration=$((phase_end_time - phase_start_time))
         if [ -n "${enablePhaseMetrics:-}" ]; then
             echo "time.$curPhase $duration" >> "$NIX_BUILD_TOP/metrics"
         fi


### PR DESCRIPTION
###### Motivation for this change
Adds enablePhaseMetrics parameter

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

