### PR TITLE
haskell/generic-builder: add functionality to split tests and builds

### DIFF
--- a/pkgs/development/haskell-modules/ListTests.hs
+++ b/pkgs/development/haskell-modules/ListTests.hs
@@ -1,0 +1,12 @@
+module Main (main) where
+
+import Distribution.Types.PackageDescription
+import Distribution.Types.LocalBuildInfo
+import Distribution.Simple.Configure
+import Distribution.Types.TestSuite
+import Distribution.Types.UnqualComponentName
+
+main :: IO ()
+main = do
+  v <- getPersistBuildConfig "dist"
+  mapM_ (putStrLn.unUnqualComponentName.testName) (testSuites $ localPkgDescr v)


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

