### PR TITLE
fix the /nix/store/w9ksnw7jf4c0vsd9v7i7n5rgaj2j3zmy-ListTests.hi: openBinaryFile: permission denied (Permission denied) errors on darwin

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -276,7 +276,7 @@ stdenv.mkDerivation ({
 
     echo setupCompileFlags: $setupCompileFlags
     ${nativeGhcCommand} $setupCompileFlags --make -o Setup -odir $TMPDIR -hidir $TMPDIR $i
-    ${optionalString splitCheck "${nativeGhcCommand} $setupCompileFlags ${./ListTests.hs} -o ListTests"}
+    ${optionalString splitCheck "${nativeGhcCommand} $setupCompileFlags ${./ListTests.hs} -o ListTests -odir $TMPDIR -hidir $TMPDIR"}
 
     runHook postCompileBuildDriver
   '';


### PR DESCRIPTION
###### Motivation for this change

https://hydra.iohk.io/build/283550/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

