### PR TITLE
haskellPackages/generic-builder: fix ListTests

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -285,7 +285,11 @@ stdenv.mkDerivation ({
 
     echo setupCompileFlags: $setupCompileFlags
     ${nativeGhcCommand} $setupCompileFlags --make -o Setup -odir $TMPDIR -hidir $TMPDIR $i
-    ${optionalString splitCheck "${nativeGhcCommand} $setupCompileFlags ${./ListTests.hs} -o ListTests -odir $TMPDIR -hidir $TMPDIR"}
+    ${optionalString splitCheck ''
+      HI_TMP_DIR=$(mktemp -d)
+      ${nativeGhcCommand} $setupCompileFlags ${./ListTests.hs} -o ListTests -odir $HI_TMP_DIR -hidir $HI_TMP_DIR
+      rm -rf $HI_TMP_DIR
+    ''}
 
     runHook postCompileBuildDriver
   '';


### PR DESCRIPTION
###### Motivation for this change
Fixes tmp dir colliding with cabal when building ListTests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

