### PR TITLE
enable running tests as a seperate derivation

### DIFF
--- a/pkgs/development/haskell-modules/ListTests.hs
+++ b/pkgs/development/haskell-modules/ListTests.hs
@@ -1,0 +1,12 @@
+module Main (main) where
+
+import Distribution.Types.PackageDescription
+import Distribution.Types.LocalBuildInfo
+import Distribution.Simple.Configure
+import Distribution.Types.TestSuite
+import Distribution.Types.UnqualComponentName
+
+main :: IO ()
+main = do
+  v <- getPersistBuildConfig "dist"
+  mapM_ (putStrLn.unUnqualComponentName.testName) (testSuites $ localPkgDescr v)

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -1,5 +1,6 @@
 { stdenv, buildPackages, buildHaskellPackages, ghc
 , jailbreak-cabal, hscolour, cpphs, nodejs, shellFor
+, runCommandNoCC
 }:
 
 let
@@ -21,6 +22,7 @@ in
 , buildFlags ? []
 , description ? ""
 , doCheck ? !isCross && stdenv.lib.versionOlder "7.4" ghc.version
+, splitCheck ? false
 , doBenchmark ? false
 , doHoogle ? true
 , editedCabalFile ? null
@@ -217,7 +219,7 @@ stdenv.mkDerivation ({
   inherit enablePhaseMetrics;
   name = "${pname}-${version}";
 
-  outputs = [ "out" ] ++ (optional enableSeparateDataOutput "data") ++ (optional enableSeparateDocOutput "doc");
+  outputs = [ "out" ] ++ (optional enableSeparateDataOutput "data") ++ (optional enableSeparateDocOutput "doc") ++ (optional splitCheck "testdata");
   setOutputFlags = false;
 
   pos = builtins.unsafeGetAttrPos "pname" args;
@@ -320,7 +322,11 @@ stdenv.mkDerivation ({
 
     echo setupCompileFlags: $setupCompileFlags
     ${nativeGhcCommand} $setupCompileFlags --make -o Setup -odir $TMPDIR -hidir $TMPDIR $i
-
+    ${optionalString splitCheck ''
+      HI_TMP_DIR=$(mktemp -d)
+      ${nativeGhcCommand} $setupCompileFlags ${./ListTests.hs} -o ListTests -odir $HI_TMP_DIR -hidir $HI_TMP_DIR
+      rm -rf $HI_TMP_DIR
+    ''}
     runHook postCompileBuildDriver
   '';
 
@@ -353,7 +359,8 @@ stdenv.mkDerivation ({
 
   inherit doCheck;
 
-  checkPhase = ''
+  checkPhase = if splitCheck then ''
+  '' else ''
     runHook preCheck
     ${setupCommand} test ${testTarget}
     runHook postCheck
@@ -413,6 +420,15 @@ stdenv.mkDerivation ({
     mkdir -p $doc
     ''}
     ${optionalString enableSeparateDataOutput "mkdir -p $data"}
+    ${optionalString splitCheck ''
+      mkdir -pv $testdata/bin
+      ./ListTests > $NIX_BUILD_TOP/test-names
+      for x in $(cat $NIX_BUILD_TOP/test-names); do
+        if [ -f dist/build/$x/$x ]; then
+          cp -v "dist/build/$x/$x" $testdata/bin/
+        fi
+      done
+    ''}
 
     mkdir -p $out/nix-support
     touch $out/nix-support/bintools-no-addLDVars
@@ -445,6 +461,20 @@ stdenv.mkDerivation ({
     env = shellFor {
       packages = p: [ drv ];
     };
+
+    testrun = runCommandNoCC "${pname}-test" { src = drv.src; } ''
+      unpackPhase
+      sourceRoot=$(realpath $sourceRoot)
+      mkdir $out
+      pushd ${drv.testdata}/bin
+      for test in *; do
+        pushd $sourceRoot
+        ${drv.testdata}/bin/''${test} | tee $out/''${test}.log
+        popd
+      done
+      popd
+    '';
+    allTestsInClosure = builtins.concatLists ( (map (dep: if dep ? testrun then [ dep.testrun ] else []) drv.getBuildInputs.haskellBuildInputs) ++ [ [ drv.testrun ] ]);
 
   };
 


### PR DESCRIPTION
(cherry picked from commit 8a682a37f5b34d1bf1293f500796ea0e09034fdc)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

