### PR TITLE
Fix help2man.postInstall syntax error under cygwin.

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -62,7 +62,7 @@ patchShebangs() {
             # - options: something starting with a '-'
             # - environment variables: foo=bar
             if $(echo "$arg0" | grep -q -- "^-.*\|.*=.*"); then
-                echo "unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)"
+                echo "$f: unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)"
                 exit 1
             fi
 

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -5,10 +5,32 @@
 # rewritten to /nix/store/<hash>/bin/python.  Interpreters that are
 # already in the store are left untouched.
 
-fixupOutputHooks+=('if [ -z "$dontPatchShebangs" -a -e "$prefix" ]; then patchShebangs "$prefix"; fi')
+fixupOutputHooks+=(patchShebangsAuto)
+
+# Run patch shebangs on a directory.
+# patchShebangs [--build | --host] directory
+
+# Flags:
+# --build : Lookup commands available at build-time
+# --host  : Lookup commands available at runtime
+
+# Example use cases,
+# $ patchShebangs --host /nix/store/...-hello-1.0/bin
+# $ patchShebangs --build configure
 
 patchShebangs() {
+    local pathName
+
+    if [ "$1" = "--host" ]; then
+        pathName=HOST_PATH
+        shift
+    elif [ "$1" = "--build" ]; then
+        pathName=PATH
+        shift
+    fi
+
     local dir="$1"
+
     header "patching script interpreter paths in $dir"
     local f
     local oldPath
@@ -27,6 +49,14 @@ patchShebangs() {
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)
         read -r oldPath arg0 args <<< "$oldInterpreterLine"
 
+        if [ -z "$pathName" ]; then
+            if [ -n "$strictDeps" ] && [[ "$f" = "$NIX_STORE"* ]]; then
+                pathName=HOST_PATH
+            else
+                pathName=PATH
+            fi
+        fi
+
         if $(echo "$oldPath" | grep -q "/bin/env$"); then
             # Check for unsupported 'env' functionality:
             # - options: something starting with a '-'
@@ -35,14 +65,17 @@ patchShebangs() {
                 echo "unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)"
                 exit 1
             fi
-            newPath="$(command -v "$arg0" || true)"
+
+            newPath="$(PATH="${!pathName}" command -v "$arg0" || true)"
         else
             if [ "$oldPath" = "" ]; then
                 # If no interpreter is specified linux will use /bin/sh. Set
                 # oldpath="/bin/sh" so that we get /nix/store/.../sh.
                 oldPath="/bin/sh"
             fi
-            newPath="$(command -v "$(basename "$oldPath")" || true)"
+
+            newPath="$(PATH="${!pathName}" command -v "$(basename "$oldPath")" || true)"
+
             args="$arg0 $args"
         fi
 
@@ -64,4 +97,18 @@ patchShebangs() {
     done
 
     stopNest
+}
+
+patchShebangsAuto () {
+    if [ -z "$dontPatchShebangs" -a -e "$prefix" ]; then
+
+        # Dev output will end up being run on the build platform. An
+        # example case of this is sdl2-config. Otherwise, we can just
+        # use the runtime path (--host).
+        if [ "$output" != out ] && [ "$output" = "${!outputDev}" ]; then
+            patchShebangs --build "$prefix"
+        else
+            patchShebangs --host "$prefix"
+        fi
+    fi
 }

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -19,9 +19,8 @@ patchShebangs() {
     local newInterpreterLine
 
     find "$dir" -type f -perm -0100 | while read f; do
-        if [ "$(head -1 "$f" | head -c+2)" != '#!' ]; then
-            # missing shebang => not a script
-            continue
+        if ! isScript "$f"; then
+          continue
         fi
 
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -19,9 +19,7 @@ patchShebangs() {
     local newInterpreterLine
 
     find "$dir" -type f -perm -0100 | while read f; do
-        if ! isScript "$f"; then
-          continue
-        fi
+        isScript "$f" || continue
 
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)
         read -r oldPath arg0 args <<< "$oldInterpreterLine"

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -18,7 +18,10 @@ patchShebangs() {
     local oldInterpreterLine
     local newInterpreterLine
 
-    find "$dir" -type f -perm -0100 | while read f; do
+    [ -e "$dir" ] || return 0
+
+    local f
+    while IFS= read -r -d $'\0' f; do
         isScript "$f" || continue
 
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)
@@ -58,7 +61,7 @@ patchShebangs() {
                 rm "$f.timestamp"
             fi
         fi
-    done
+    done < <(find "$dir" -type f -perm -0100 -print0)
 
     stopNest
 }

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -5,32 +5,10 @@
 # rewritten to /nix/store/<hash>/bin/python.  Interpreters that are
 # already in the store are left untouched.
 
-fixupOutputHooks+=(patchShebangsAuto)
-
-# Run patch shebangs on a directory.
-# patchShebangs [--build | --host] directory
-
-# Flags:
-# --build : Lookup commands available at build-time
-# --host  : Lookup commands available at runtime
-
-# Example use cases,
-# $ patchShebangs --host /nix/store/...-hello-1.0/bin
-# $ patchShebangs --build configure
+fixupOutputHooks+=('if [ -z "$dontPatchShebangs" -a -e "$prefix" ]; then patchShebangs "$prefix"; fi')
 
 patchShebangs() {
-    local pathName
-
-    if [ "$1" = "--host" ]; then
-        pathName=HOST_PATH
-        shift
-    elif [ "$1" = "--build" ]; then
-        pathName=PATH
-        shift
-    fi
-
     local dir="$1"
-
     header "patching script interpreter paths in $dir"
     local f
     local oldPath
@@ -49,14 +27,6 @@ patchShebangs() {
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)
         read -r oldPath arg0 args <<< "$oldInterpreterLine"
 
-        if [ -z "$pathName" ]; then
-            if [ -n "$strictDeps" ] && [[ "$f" = "$NIX_STORE"* ]]; then
-                pathName=HOST_PATH
-            else
-                pathName=PATH
-            fi
-        fi
-
         if $(echo "$oldPath" | grep -q "/bin/env$"); then
             # Check for unsupported 'env' functionality:
             # - options: something starting with a '-'
@@ -65,17 +35,14 @@ patchShebangs() {
                 echo "$f: unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)"
                 exit 1
             fi
-
-            newPath="$(PATH="${!pathName}" command -v "$arg0" || true)"
+            newPath="$(command -v "$arg0" || true)"
         else
             if [ "$oldPath" = "" ]; then
                 # If no interpreter is specified linux will use /bin/sh. Set
                 # oldpath="/bin/sh" so that we get /nix/store/.../sh.
                 oldPath="/bin/sh"
             fi
-
-            newPath="$(PATH="${!pathName}" command -v "$(basename "$oldPath")" || true)"
-
+            newPath="$(command -v "$(basename "$oldPath")" || true)"
             args="$arg0 $args"
         fi
 
@@ -97,18 +64,4 @@ patchShebangs() {
     done
 
     stopNest
-}
-
-patchShebangsAuto () {
-    if [ -z "$dontPatchShebangs" -a -e "$prefix" ]; then
-
-        # Dev output will end up being run on the build platform. An
-        # example case of this is sdl2-config. Otherwise, we can just
-        # use the runtime path (--host).
-        if [ "$output" != out ] && [ "$output" = "${!outputDev}" ]; then
-            patchShebangs --build "$prefix"
-        else
-            patchShebangs --host "$prefix"
-        fi
-    fi
 }


### PR DESCRIPTION
###### Motivation for this change

Did the fix and [submitted this patch upstream](https://github.com/NixOS/nixpkgs/pull/49836) before seeing the patch was already in #7... Anyway this is a requirement to get https://github.com/input-output-hk/plutus/pull/244 pass build checks.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

