### PR TITLE
ghcjs cross

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -162,4 +162,13 @@ rec {
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
     platform = {};
   };
+
+  #
+  # Ghcjs
+  #
+
+  ghcjs = {
+    config = "js-unknown-ghcjs";
+    platform = {};
+  };
 }

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -171,4 +171,18 @@ rec {
     config = "js-unknown-ghcjs";
     platform = {};
   };
+
+  #
+  # Asterius
+  #
+
+  asterius32 = {
+    config = "wasm32-unknown-asterius";
+    platform = {};
+  };
+
+  asterius64 = {
+    config = "wasm64-unknown-asterius";
+    platform = {};
+  };
 }

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -19,6 +19,7 @@ rec {
     isRiscV        = { cpu = { family = "riscv"; }; };
     isSparc        = { cpu = { family = "sparc"; }; };
     isWasm         = { cpu = { family = "wasm"; }; };
+    isJavaScript   = { cpu = { family = "js"; }; };
 
     is32bit        = { cpu = { bits = 32; }; };
     is64bit        = { cpu = { bits = 64; }; };
@@ -46,6 +47,8 @@ rec {
 
     isEfi          = map (family: { cpu.family = family; })
                        [ "x86" "arm" "aarch64" ];
+
+    isGhcjs        = { kernel = kernels.ghcjs; };
 
     # Deprecated after 18.03
     isArm = isAarch32;

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -18,6 +18,8 @@ rec {
     isMips         = { cpu = { family = "mips"; }; };
     isRiscV        = { cpu = { family = "riscv"; }; };
     isSparc        = { cpu = { family = "sparc"; }; };
+    isWasm32       = { cpu = cpuTypes.wasm32; };
+    isWasm64       = { cpu = cpuTypes.wasm64; };
     isWasm         = { cpu = { family = "wasm"; }; };
     isJavaScript   = { cpu = { family = "js"; }; };
 
@@ -49,6 +51,7 @@ rec {
                        [ "x86" "arm" "aarch64" ];
 
     isGhcjs        = { kernel = kernels.ghcjs; };
+    isAsterius     = { kernel = kernels.asterius; };
 
     # Deprecated after 18.03
     isArm = isAarch32;

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -101,6 +101,8 @@ rec {
 
     wasm32   = { bits = 32; significantByte = littleEndian; family = "wasm"; };
     wasm64   = { bits = 64; significantByte = littleEndian; family = "wasm"; };
+
+    js       = { bits = 32; significantByte = littleEndian; family = "js"; };
   };
 
   ################################################################################
@@ -178,6 +180,7 @@ rec {
     openbsd = { execFormat = elf;     families = { inherit bsd; }; };
     solaris = { execFormat = elf;     families = { }; };
     windows = { execFormat = pe;      families = { }; };
+    ghcjs   = { execFormat = unknown; families = { }; };
   } // { # aliases
     # 'darwin' is the kernel for all of them. We choose macOS by default.
     darwin = kernels.macos;
@@ -267,6 +270,8 @@ rec {
       else if (elemAt l 2 == "mingw32") # autotools breaks on -gnu for window
         then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "windows";  abi = "gnu"; }
       else if hasPrefix "netbsd" (elemAt l 2)
+        then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
+      else if (elemAt l 2 == "ghcjs")
         then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
       else throw "Target specification with 3 components is ambiguous";
     "4" =    { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; abi = elemAt l 3; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -181,6 +181,7 @@ rec {
     solaris = { execFormat = elf;     families = { }; };
     windows = { execFormat = pe;      families = { }; };
     ghcjs   = { execFormat = unknown; families = { }; };
+    asterius = { execFormat = unknown; families = { }; };
   } // { # aliases
     # 'darwin' is the kernel for all of them. We choose macOS by default.
     darwin = kernels.macos;
@@ -272,6 +273,8 @@ rec {
       else if hasPrefix "netbsd" (elemAt l 2)
         then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
       else if (elemAt l 2 == "ghcjs")
+        then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
+      else if (elemAt l 2 == "asterius")
         then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
       else throw "Target specification with 3 components is ambiguous";
     "4" =    { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; abi = elemAt l 3; };

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -148,6 +148,8 @@ let
       inherit cc;
     }
 
+    // (if targetPlatform.isGhcjs then { cc = null; } else {})
+
     # Propagate any extra attributes.  For instance, we use this to
     # "lift" packages like curl from the final stdenv for Linux to
     # all-packages.nix for that platform (meaning that it has a line

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -57,7 +57,7 @@ let
       ../../build-support/setup-hooks/move-lib64.sh
       ../../build-support/setup-hooks/set-source-date-epoch-to-latest.sh
        ]
-    ++ lib.optional (!hostPlatform.isGhcjs) cc;
+    ++ lib.optional (!hostPlatform.isGhcjs && !hostPlatform.isAsterius) cc;
 
   defaultBuildInputs = extraBuildInputs;
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -56,8 +56,8 @@ let
       ../../build-support/setup-hooks/move-sbin.sh
       ../../build-support/setup-hooks/move-lib64.sh
       ../../build-support/setup-hooks/set-source-date-epoch-to-latest.sh
-      cc
-    ];
+       ]
+    ++ lib.optional (!hostPlatform.isGhcjs) cc;
 
   defaultBuildInputs = extraBuildInputs;
 
@@ -147,8 +147,6 @@ let
 
       inherit cc;
     }
-
-    // (if targetPlatform.isGhcjs then { cc = null; } else {})
 
     # Propagate any extra attributes.  For instance, we use this to
     # "lift" packages like curl from the final stdenv for Linux to

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -47,7 +47,7 @@ let
 in {
   lib = haskellLib;
 
-  compiler = rec {
+  compiler = {
 
     ghc7103Binary = callPackage ../development/compilers/ghc/7.10.3-binary.nix { };
     ghc821Binary = callPackage ../development/compilers/ghc/8.2.1-binary.nix { };
@@ -74,13 +74,11 @@ in {
       buildLlvmPackages = buildPackages.llvmPackages_5;
       llvmPackages = pkgs.llvmPackages_5;
     };
-    ghc844 = builtins.trace pkgs.stdenv.targetPlatform.config (if pkgs.stdenv.targetPlatform.isGhcjs
-      then buildPackages.haskell.compiler.ghcjs84
-      else callPackage ../development/compilers/ghc/8.4.4.nix {
-        bootPkgs = mkBootPkgs "ghc844" "ghc821Binary";
-        buildLlvmPackages = buildPackages.llvmPackages_5;
-        llvmPackages = pkgs.llvmPackages_5;
-      });
+    ghc844 = callPackage ../development/compilers/ghc/8.4.4.nix {
+      bootPkgs = mkBootPkgs "ghc844" "ghc821Binary";
+      buildLlvmPackages = buildPackages.llvmPackages_5;
+      llvmPackages = pkgs.llvmPackages_5;
+    };
     ghc861 = callPackage ../development/compilers/ghc/8.6.1.nix {
       bootPkgs = mkBootPkgs "ghc861" "ghc822";
       buildLlvmPackages = buildPackages.llvmPackages_6;
@@ -127,23 +125,23 @@ in {
     ghcjs = compiler.ghcjs84;
     # Use `import` because `callPackage inside`.
     ghcjs710 = import ../development/compilers/ghcjs/7.10 {
-      bootPkgs = packages.ghc7103;
+      bootPkgs = buildPackages.ghc7103;
       inherit (pkgs) cabal-install;
       inherit (buildPackages) fetchgit fetchFromGitHub;
     };
     # `import` on purpose; see above.
     ghcjs80 = import ../development/compilers/ghcjs/8.0 {
-      bootPkgs = packages.ghc802;
+      bootPkgs = buildPackages.ghc802;
       inherit (pkgs) cabal-install;
       inherit (buildPackages) fetchgit fetchFromGitHub;
     };
     ghcjs82 = callPackage ../development/compilers/ghcjs-ng {
-      bootPkgs = packages.ghc822;
+      bootPkgs = buildPackages.ghc822;
       ghcjsSrcJson = ../development/compilers/ghcjs-ng/8.2/git.json;
       stage0 = ../development/compilers/ghcjs-ng/8.2/stage0.nix;
     };
     ghcjs84 = callPackage ../development/compilers/ghcjs-ng {
-      bootPkgs = packages.ghc843;
+      bootPkgs = buildPackages.ghc843;
       ghcjsSrcJson = ../development/compilers/ghcjs-ng/8.4/git.json;
       stage0 = ../development/compilers/ghcjs-ng/8.4/stage0.nix;
       ghcjsDepOverrides = callPackage ../development/compilers/ghcjs-ng/8.4/dep-overrides.nix {};
@@ -158,7 +156,33 @@ in {
     in pkgs.recurseIntoAttrs (pkgs.lib.genAttrs
       integerSimpleGhcNames
       (name: compiler."${name}".override { enableIntegerSimple = true; }));
-  };
+  } //
+  ( if pkgs.stdenv.hostPlatform.isGhcjs
+    then {
+      ghc802 = compiler.ghcjs80;
+      ghc822 = compiler.ghcjs82;
+      ghc843 = compiler.ghcjs84;
+      ghc844 = compiler.ghcjs84;
+      ghc861 = compiler.ghcjs86;
+      ghc862 = compiler.ghcjs86;
+      ghc863 = compiler.ghcjs86;
+      ghc864 = compiler.ghcjs86;
+    }
+    else {}
+  ) //
+  ( if pkgs.stdenv.hostPlatform.isAsterius
+    then {
+      ghc802 = compiler.asterius;
+      ghc822 = compiler.asterius;
+      ghc843 = compiler.asterius;
+      ghc844 = compiler.asterius;
+      ghc861 = compiler.asterius;
+      ghc862 = compiler.asterius;
+      ghc863 = compiler.asterius;
+      ghc864 = compiler.asterius;
+    }
+    else {}
+  );
 
   # Default overrides that are applied to all package sets.
   packageOverrides = self : super : {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -47,7 +47,7 @@ let
 in {
   lib = haskellLib;
 
-  compiler = {
+  compiler = rec {
 
     ghc7103Binary = callPackage ../development/compilers/ghc/7.10.3-binary.nix { };
     ghc821Binary = callPackage ../development/compilers/ghc/8.2.1-binary.nix { };
@@ -74,11 +74,13 @@ in {
       buildLlvmPackages = buildPackages.llvmPackages_5;
       llvmPackages = pkgs.llvmPackages_5;
     };
-    ghc844 = callPackage ../development/compilers/ghc/8.4.4.nix {
-      bootPkgs = mkBootPkgs "ghc844" "ghc821Binary";
-      buildLlvmPackages = buildPackages.llvmPackages_5;
-      llvmPackages = pkgs.llvmPackages_5;
-    };
+    ghc844 = builtins.trace pkgs.stdenv.targetPlatform.config (if pkgs.stdenv.targetPlatform.isGhcjs
+      then buildPackages.haskell.compiler.ghcjs84
+      else callPackage ../development/compilers/ghc/8.4.4.nix {
+        bootPkgs = mkBootPkgs "ghc844" "ghc821Binary";
+        buildLlvmPackages = buildPackages.llvmPackages_5;
+        llvmPackages = pkgs.llvmPackages_5;
+      });
     ghc861 = callPackage ../development/compilers/ghc/8.6.1.nix {
       bootPkgs = mkBootPkgs "ghc861" "ghc822";
       buildLlvmPackages = buildPackages.llvmPackages_6;


### PR DESCRIPTION
This adds `ghcjs` in the form of a cross compiler to `js-unknown-ghcjs` to nix. Thus we can treat ghcjs like a cross compiler instead of a separate compiler.

