### PR TITLE
ghc: don’t add libiconv automatically

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2467,6 +2467,23 @@ addEnvHooks "$hostOffset" myBashFunction
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term>
+      libiconv, libintl
+     </term>
+     <listitem>
+       <para>
+	 A few libraries automatically add to
+	 <literal>NIX_LDFLAGS</literal> their library, making their
+	 symbols automatically available to the linker. This includes
+	 libiconv and libintl (gettext). This is done to provide
+	 compatibility between GNU Linux, where libiconv and libintl
+	 are bundled in, and other systems where that might not be the
+	 case. Sometimes, this behavior is not desired. To disable
+	 this behavior, set <literal>dontAddExtraLibs</literal>.
+       </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </section>

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -137,6 +137,9 @@ stdenv.mkDerivation rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -139,6 +139,9 @@ stdenv.mkDerivation rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -206,6 +206,9 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -179,6 +179,9 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -182,6 +182,9 @@ stdenv.mkDerivation (rec {
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   nativeBuildInputs = [
     perl autoconf automake m4 python3
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -179,11 +179,11 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
-  # Make sure we never relax`$PATH` and hooks support for compatability.
-  strictDeps = true;
-
   # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
   dontAddExtraLibs = true;
+
+  # Make sure we never relax`$PATH` and hooks support for compatability.
+  strictDeps = true;
 
   nativeBuildInputs = [
     perl autoconf automake m4 python3

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -164,6 +164,9 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/8.6.2.nix
+++ b/pkgs/development/compilers/ghc/8.6.2.nix
@@ -164,6 +164,9 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/8.6.3.nix
+++ b/pkgs/development/compilers/ghc/8.6.3.nix
@@ -164,6 +164,9 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/8.6.4.nix
+++ b/pkgs/development/compilers/ghc/8.6.4.nix
@@ -169,6 +169,9 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -149,6 +149,9 @@ stdenv.mkDerivation (rec {
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   nativeBuildInputs = [
     perl autoconf automake m4 python3
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -146,11 +146,11 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
-  # Make sure we never relax`$PATH` and hooks support for compatability.
-  strictDeps = true;
-
   # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
   dontAddExtraLibs = true;
+
+  # Make sure we never relax`$PATH` and hooks support for compatability.
+  strictDeps = true;
 
   nativeBuildInputs = [
     perl autoconf automake m4 python3

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -10,7 +10,7 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 
 # libintl must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
-if [ ! -z "@gettextNeedsLdflags@" ]; then
+if [ -n "@gettextNeedsLdflags@" -a -z "$dontAddExtraLibs" ]; then
     # See pkgs/build-support/setup-hooks/role.bash
     getHostRole
     export NIX_${role_pre}LDFLAGS+=" -lintl"

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -2,5 +2,7 @@
 # it doesn't hurt to have it in Glibc either though
 
 # See pkgs/build-support/setup-hooks/role.bash
-getHostRole
-export NIX_${role_pre}LDFLAGS+=" -liconv"
+if [ -z "$dontAddExtraLibs" ]; then
+    getHostRole
+    export NIX_${role_pre}LDFLAGS+=" -liconv"
+fi


### PR DESCRIPTION
Cherry-pick the fix for https://github.com/NixOS/nixpkgs/issues/46814.

This is in upstream 18.09, but I don't know if we can easily fast-forward to pick up all those changes, so I just picked the commit.